### PR TITLE
Run pytest in ubuntu latest

### DIFF
--- a/.github/workflows/run-pytest-on-posix.yml
+++ b/.github/workflows/run-pytest-on-posix.yml
@@ -8,7 +8,7 @@ jobs:
 
       steps:
 
-        - name: Install linux-modules-extra-$(uname -r)
+        - name: Install missing kernel module file for vcan
           run: sudo apt install linux-modules-extra-$(uname -r)
 
         - name: Install can kernel modules
@@ -17,13 +17,13 @@ jobs:
             sudo modprobe can-raw
             sudo modprobe vcan
 
-        - name: Set up vcan0
+        - name: Set up vcan0 interface
           run: |
             sudo ip link add dev vcan0 type vcan
             sudo ip link set vcan0 mtu 16
             sudo ip link set up vcan0
 
-        - name: Show interface info
+        - name: Show all interface info, vcan0 should be set up
           run: ip a
 
         - name: Checkout repository
@@ -44,7 +44,7 @@ jobs:
           with:
             python-version: '3.10'
 
-        - name: Install python dependencies
+        - name: Install python dependencies for tests
           run: |
             pip install -r test/pyTest/requirements.txt
             cd tools/UdsTool

--- a/.github/workflows/run-pytest-on-posix.yml
+++ b/.github/workflows/run-pytest-on-posix.yml
@@ -1,0 +1,59 @@
+name: Run pytest for posix platform
+
+on: [push, pull_request]
+
+jobs:
+    run-pytest-on-posix:
+      runs-on: ubuntu-latest
+
+      steps:
+
+        - name: Install linux-modules-extra-$(uname -r)
+          run: sudo apt install linux-modules-extra-$(uname -r)
+
+        - name: Install can kernel modules
+          run: |
+            sudo modprobe can
+            sudo modprobe can-raw
+            sudo modprobe vcan
+
+        - name: Set up vcan0
+          run: |
+            sudo ip link add dev vcan0 type vcan
+            sudo ip link set vcan0 mtu 16
+            sudo ip link set up vcan0
+
+        - name: Show interface info
+          run: ip a
+
+        - name: Checkout repository
+          uses: actions/checkout@v4
+
+        - name: Set up CMake
+          uses: jwlawson/actions-setup-cmake@v2
+          with:
+            cmake-version: '3.22.x'
+
+        - name: Build posix target
+          run: |
+            cmake -B cmake-build-posix -S executables/referenceApp
+            cmake --build cmake-build-posix --target app.referenceApp -j
+
+        - name: Set up python 3.10
+          uses: actions/setup-python@v5
+          with:
+            python-version: '3.10'
+
+        - name: Install python dependencies
+          run: |
+            pip install -r test/pyTest/requirements.txt
+            cd tools/UdsTool
+            pip install .
+
+        - name: Install tmux (used in tests involving UdsTool)
+          run: sudo apt install -y tmux
+
+        - name: Run tests
+          run: |
+            cd test/pyTest
+            pytest

--- a/.github/workflows/run-pytest-on-posix.yml
+++ b/.github/workflows/run-pytest-on-posix.yml
@@ -50,10 +50,7 @@ jobs:
             cd tools/UdsTool
             pip install .
 
-        - name: Install tmux (used in tests involving UdsTool)
-          run: sudo apt install -y tmux
-
         - name: Run tests
           run: |
             cd test/pyTest
-            pytest
+            pytest --target=posix


### PR DESCRIPTION
The github runner `ubuntu-latest` is built with support for SocketCAN, it is just missing one of the kernel module files - `vcan.ko.zst`.
Running `sudo apt install linux-modules-extra-$(uname -r)` fetches the missing kernel module file, then the interface `vcan0` needed for tests can be set up and the tests run and pass.