### PR TITLE
Add stack usage in ArmNoneEabi.cmake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ venv
 .envrc
 .DS_Store
 *.egg-info
+tools/puncover_tool/output/

--- a/admin/cmake/ArmNoneEabi.cmake
+++ b/admin/cmake/ArmNoneEabi.cmake
@@ -21,7 +21,7 @@ set(C_COMMON_FLAGS
     "${CPU_BUILD_FLAGS} -mthumb -fshort-enums \
 -mno-unaligned-access -Wno-psabi \
 -fno-asynchronous-unwind-tables -fno-builtin -fno-common \
--ffunction-sections -fdata-sections")
+-ffunction-sections -fdata-sections -fstack-usage")
 
 set(CMAKE_ASM_FLAGS "-g -mcpu=cortex-m4")
 set(CMAKE_C_FLAGS "${C_COMMON_FLAGS} -ffreestanding")


### PR DESCRIPTION
- For viewing the Stack Usage on Puncover
- .su files will be generated under cmake-build-s32k148
- view Stack Worst-Case Scenarios and Stack Usage on puncover tools/puncover_tool/output/index.html
- Add generated tools/puncover_tool/output to .gitignore