### PR TITLE
Fix link to DoxygenMainPage.md

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -30,7 +30,7 @@ The entry point HTML page is found at `doc/dev/build/html/doc/dev/index.html`.
 
  Using the settings file `doc/api/Doxyfile`, Doxygen generates the documentation from formatted
 comments in the C/C++ code across all relevant subfolders; see
-[Doxygen Main Page](DoxygenMainPage.md) for details.
+[Doxygen Main Page](api/DoxygenMainPage.md) for details.
 
 To build the documentation, go to `doc/api` and call:
 ```bash


### PR DESCRIPTION
## Summary
- The `[Doxygen Main Page](DoxygenMainPage.md)` link in `doc/README.md` resolves to `doc/DoxygenMainPage.md`, which does not exist.
- The actual file lives at `doc/api/DoxygenMainPage.md`; updating the link to `api/DoxygenMainPage.md` so it resolves correctly when viewing `doc/README.md` on GitHub or in any Markdown renderer.

## Test plan
- [ ] Open `doc/README.md` on GitHub and click the "Doxygen Main Page" link — it should navigate to `doc/api/DoxygenMainPage.md` instead of 404.